### PR TITLE
Use punkt from GitHub for now

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -66,7 +66,7 @@ dependencies = [
  "glob 0.2.11 (registry+https://github.com/rust-lang/crates.io-index)",
  "itertools 0.8.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "lazy_static 1.3.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "punkt 1.0.5 (registry+https://github.com/rust-lang/crates.io-index)",
+ "punkt 1.0.5 (git+https://github.com/ferristseng/rust-punkt)",
  "rand 0.6.5 (registry+https://github.com/rust-lang/crates.io-index)",
  "regex 1.1.5 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde 1.0.90 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -232,7 +232,7 @@ dependencies = [
 [[package]]
 name = "punkt"
 version = "1.0.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
+source = "git+https://github.com/ferristseng/rust-punkt#3ac70e705cd5a6ce1202b5eaed0c228f042f88f4"
 dependencies = [
  "num 0.1.42 (registry+https://github.com/rust-lang/crates.io-index)",
  "phf 0.7.24 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -566,7 +566,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 "checksum phf_macros 0.7.24 (registry+https://github.com/rust-lang/crates.io-index)" = "bdb45e833315153371697760dad1831da99ce41884162320305e4f123ca3fe37"
 "checksum phf_shared 0.7.24 (registry+https://github.com/rust-lang/crates.io-index)" = "234f71a15de2288bcb7e3b6515828d22af7ec8598ee6d24c3b526fa0a80b67a0"
 "checksum proc-macro2 0.4.27 (registry+https://github.com/rust-lang/crates.io-index)" = "4d317f9caece796be1980837fd5cb3dfec5613ebdb04ad0956deea83ce168915"
-"checksum punkt 1.0.5 (registry+https://github.com/rust-lang/crates.io-index)" = "54f746236290dbeb84c89a7123b8ac32b1a3d42d603a5d59812c14bb07b937ea"
+"checksum punkt 1.0.5 (git+https://github.com/ferristseng/rust-punkt)" = "<none>"
 "checksum quote 0.6.12 (registry+https://github.com/rust-lang/crates.io-index)" = "faf4799c5d274f3868a4aae320a0a182cbd2baee377b378f080e16a23e9d80db"
 "checksum rand 0.4.6 (registry+https://github.com/rust-lang/crates.io-index)" = "552840b97013b1a26992c11eac34bdd778e464601a4c2054b5f0bff7c6761293"
 "checksum rand 0.6.5 (registry+https://github.com/rust-lang/crates.io-index)" = "6d71dacdc3c88c1fde3885a3be3fbab9f35724e6ce99467f7d9c5026132184ca"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -19,7 +19,7 @@ clap = "2.31"
 lazy_static = "1"
 itertools = "0.8"
 regex = "1"
-punkt = "1.0.5"
+punkt = { git = "https://github.com/ferristseng/rust-punkt" }
 rand = "0.6"
 toml = "0.5"
 serde = { version = "1.0", features = ["derive"] }


### PR DESCRIPTION
Punkt 1.0.5 does not work with latest Rust nightlies. The issue was fixed in the master branch, however there hasn't been a release of it. Therefore I'm changing the dependency to use the git for now. Not the best practice, I know..