### PR TITLE
Add continuous integration (AppVeyor & Travis CI)

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,6 @@
 language: rust
 dist: bionic
-rust: stable
+rust: nightly
 cache: cargo
 
 install: cargo build --release

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,8 @@
+language: rust
+dist: bionic
+rust: stable
+cache: cargo
+
+install: cargo build --release
+
+script: cargo test --verbose

--- a/README.md
+++ b/README.md
@@ -1,4 +1,5 @@
 # Common Voice Wiki Sentence Extractor
+[![Travis Build Status](https://travis-ci.org/Common-Voice/common-voice-wiki-scraper.svg?branch=master)](https://travis-ci.org/Common-Voice/common-voice-wiki-scraper) [![AppVeyor Build Status](https://ci.appveyor.com/api/projects/status/github/Common-Voice/common-voice-wiki-scraper?branch=master&svg=true)](https://ci.appveyor.com/project/Common-Voice/common-voice-wiki-scraper/history)
 
 ## Dependencies
 

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -19,9 +19,8 @@ install:
 build_script:
     - cargo build --release --target=%target%      # Builds file defined in Cargo.toml (default main.rs)
 
-#test_script:
-#    - cargo test --target=%target% --verbose       # Runs tests in "src" and "tests" folders
-#    - cargo bench --target=%target% --verbose      # Runs benchmarks in "src/lib.rs"
+test_script:
+    - cargo test --target=%target% --verbose       # Runs tests in "src" and "tests" folders
 
 artifacts:
     - path: target\$(target)\release\*voice*.*     # Publishes all files from `cargo build/test/bench --release`

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -10,10 +10,10 @@ environment:
 install:
     - git submodule update --init
     - appveyor DownloadFile https://win.rustup.rs/ -FileName rustup-init.exe  # Downloads Rustup-init 
-    - rustup-init -yv --default-toolchain %channel% --default-host %host%     # Installs Rust
+    - rustup-init -y --default-toolchain %channel% --default-host %host%      # Installs Rust
     - set PATH=%PATH%;%USERPROFILE%\.cargo\bin;%APPVEYOR_BUILD_FOLDER%        # Adds Rust tools (Cargo, Rustup, etc.) to path
-    - rustc -vV                       # Prints Rust version
-    - cargo -vV                       # Prints Cargo version
+    - rustc -V                        # Prints Rust version
+    - cargo -V                        # Prints Cargo version
     - rustup target add %target%      # Adds target platform to Rust
 
 build_script:
@@ -24,7 +24,7 @@ test_script:
 #    - cargo bench --target=%target% --verbose      # Runs benchmarks in "src/lib.rs"
 
 artifacts:                          
-    - path: target\$(target)\release\*numext*.*     # Publishes all files from `cargo build/test/bench --release`
+    - path: target\$(target)\release\*voice*.*     # Publishes all files from `cargo build/test/bench --release`
       name: $(APPVEYOR_PROJECT_NAME)-$(platform)                      # Gives it a fancy name
 
 deploy:

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -19,19 +19,19 @@ install:
 build_script:
     - cargo build --release --target=%target%      # Builds file defined in Cargo.toml (default main.rs)
 
-test_script:
-    - cargo test --target=%target% --verbose       # Runs tests in "src" and "tests" folders
+#test_script:
+#    - cargo test --target=%target% --verbose       # Runs tests in "src" and "tests" folders
 #    - cargo bench --target=%target% --verbose      # Runs benchmarks in "src/lib.rs"
 
 artifacts:
     - path: target\$(target)\release\*voice*.*     # Publishes all files from `cargo build/test/bench --release`
       name: $(APPVEYOR_PROJECT_NAME)-$(platform)                      # Gives it a fancy name
 
-deploy:
-  - provider: GitHub
-    artifact: $(APPVEYOR_PROJECT_NAME)-$(platform)
-    auth_token:
-      secure: 'hY5Mk6KOwgQ97TzEBsM7Woqr1ZIm5QTvHg8EvxMV1x8j3wk/3mNBMqWFFbEIBK0i'
-    prerelease: true
-    on:
-      appveyor_repo_tag: true
+#deploy:
+#  - provider: GitHub
+#    artifact: $(APPVEYOR_PROJECT_NAME)-$(platform)
+#    auth_token:
+#      secure: 'hY5Mk6KOwgQ97TzEBsM7Woqr1ZIm5QTvHg8EvxMV1x8j3wk/3mNBMqWFFbEIBK0i'
+#    prerelease: true
+#    on:
+#      appveyor_repo_tag: true

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,0 +1,37 @@
+image: Visual Studio 2019
+
+environment:
+  host: x86_64-pc-windows-msvc        # Triple of host platform
+  matrix:
+    - platform: x86_64                # Name (is not used other than naming things)
+      target: x86_64-pc-windows-msvc  # Triple of target platform
+      channel: stable                 # Rust release channel (stable/beta/nightly/nightly-2018-12-01)
+
+install:
+    - git submodule update --init
+    - appveyor DownloadFile https://win.rustup.rs/ -FileName rustup-init.exe  # Downloads Rustup-init 
+    - rustup-init -yv --default-toolchain %channel% --default-host %host%     # Installs Rust
+    - set PATH=%PATH%;%USERPROFILE%\.cargo\bin;%APPVEYOR_BUILD_FOLDER%        # Adds Rust tools (Cargo, Rustup, etc.) to path
+    - rustc -vV                       # Prints Rust version
+    - cargo -vV                       # Prints Cargo version
+    - rustup target add %target%      # Adds target platform to Rust
+
+build_script:
+    - cargo build --release --target=%target%      # Builds file defined in Cargo.toml (default main.rs)
+
+test_script:
+    - cargo test --target=%target% --verbose       # Runs tests in "src" and "tests" folders
+#    - cargo bench --target=%target% --verbose      # Runs benchmarks in "src/lib.rs"
+
+artifacts:                          
+    - path: target\$(target)\release\*numext*.*     # Publishes all files from `cargo build/test/bench --release`
+      name: $(APPVEYOR_PROJECT_NAME)-$(platform)                      # Gives it a fancy name
+
+deploy:
+  - provider: GitHub
+    artifact: $(APPVEYOR_PROJECT_NAME)-$(platform)
+    auth_token:
+      secure: 'hY5Mk6KOwgQ97TzEBsM7Woqr1ZIm5QTvHg8EvxMV1x8j3wk/3mNBMqWFFbEIBK0i'
+    prerelease: true
+    on:
+      appveyor_repo_tag: true

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -5,11 +5,11 @@ environment:
   matrix:
     - platform: x86_64                # Name (is not used other than naming things)
       target: x86_64-pc-windows-msvc  # Triple of target platform
-      channel: stable                 # Rust release channel (stable/beta/nightly/nightly-2018-12-01)
+      channel: nightly                # Rust release channel (stable/beta/nightly/nightly-2018-12-01)
 
 install:
     - git submodule update --init
-    - appveyor DownloadFile https://win.rustup.rs/ -FileName rustup-init.exe  # Downloads Rustup-init 
+    - appveyor DownloadFile https://win.rustup.rs/ -FileName rustup-init.exe  # Downloads Rustup-init
     - rustup-init -y --default-toolchain %channel% --default-host %host%      # Installs Rust
     - set PATH=%PATH%;%USERPROFILE%\.cargo\bin;%APPVEYOR_BUILD_FOLDER%        # Adds Rust tools (Cargo, Rustup, etc.) to path
     - rustc -V                        # Prints Rust version
@@ -23,7 +23,7 @@ test_script:
     - cargo test --target=%target% --verbose       # Runs tests in "src" and "tests" folders
 #    - cargo bench --target=%target% --verbose      # Runs benchmarks in "src/lib.rs"
 
-artifacts:                          
+artifacts:
     - path: target\$(target)\release\*voice*.*     # Publishes all files from `cargo build/test/bench --release`
       name: $(APPVEYOR_PROJECT_NAME)-$(platform)                      # Gives it a fancy name
 


### PR DESCRIPTION
Adds continuous integration with both AppVeyor and Travis CI. 

For optimal integration with GitHub, [AppVeyor](https://github.com/marketplace/appveyor) and [Travis CI](https://github.com/marketplace/travis-ci) needs to be enabled on the GitHub Marketplace.

AppVeyor builds & tests on Windows with Rust nightly, while Travis builds & tests on Linux with Rust nightly.

AppVeyor also publishes the artifacts with each build. When tagging a new (pre)release, AppVeyor will also upload `libcommon_voice_yotp.rlib`, `libcommon_voice_yotp.d`, `common_voice_yotp.pdb`, `common_voice_yotp.exe` and `common_voice_yotp.d` to GitHub, creating a release page [like this](https://github.com/EwoutH/common-voice-wiki-scraper/releases/tag/2019-12-10-test0).

To enable uploading to GitHub Releases, you need update this patch with your personal authentication token. You can generate one on https://github.com/settings/tokens/new (select `public_repo` as scope), and then encrypt it with https://ci.appveyor.com/tools/encrypt. Replace the current token on line 34 (after `secure:`) in the `appveyor.yml` file.

